### PR TITLE
Fix crash on dual start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Protect start function from being executed when libpax is already started
 
 ## [1.1.0] - 2022-10-29
 - Adapt Wifi country settings to ESP IDF v4.4 Wi-Fi API


### PR DESCRIPTION
The library crashes fatal when the start method is called twice. 
- Fix by protecting start without being in STOPPED state.
- Added STOPPED/STARTED State management for protecting dual start.